### PR TITLE
CSharp gain 30% in perf : Do not use an Iterator inside a hot loop

### DIFF
--- a/cs.cs
+++ b/cs.cs
@@ -28,12 +28,14 @@ class longestPathFinder{
     public int getLongestPath(List<node> nodes, int nodeID, bool[] visited){
 	visited[nodeID] = true;
 	int max=0;
-	foreach(route neighbour in nodes[nodeID].neighbours){
+	var neighboursOfID = nodes[nodeID].neighbours;
+	for(int i = 0; i < neighboursOfID.Count; i++){
+		var neighbour = neighboursOfID[i];
 	    if (!visited[neighbour.dest]){
-		int dist = neighbour.cost + getLongestPath(nodes, neighbour.dest, visited);
-		if (dist > max){
-		    max = dist;
-		}
+			int dist = neighbour.cost + getLongestPath(nodes, neighbour.dest, visited);
+			if (dist > max){
+			    max = dist;
+			}
 	    }    
 	}
 	visited[nodeID] = false;


### PR DESCRIPTION
Change from an iterator generating allocations inside a hot loop to a
simple for loop.
It goes from 3223 to 2083.
