### PR TITLE
cosmetic cleanups to the OCaml code

### DIFF
--- a/makefile
+++ b/makefile
@@ -29,7 +29,7 @@ haskellprof: hs.hs
 	ghc hs.hs -O3 -prof -fprof-auto -caf-all -fforce-recomp -rtsopts
 
 ocaml: ml.ml
-	ocamlfind ocamlopt -linkpkg -package str,unix -noassert -unsafe -fno-PIC -nodynlink -inline 100 -o ml ml.ml
+	ocamlfind ocamlopt -linkpkg -package unix -noassert -unsafe -fno-PIC -nodynlink -inline 100 -o ml ml.ml
 
 lisp: lisp.lisp
 	sbcl --core /usr/local/lib/sbcl/sbcl.core --load lisp.lisp --non-interactive

--- a/ml.ml
+++ b/ml.ml
@@ -1,82 +1,46 @@
-open List
-open Unix
-open Printf
-       
-type route = {dest: int; cost: int}
-
-type node = route list
-
-type node2 = int array
-		  
-
-let node2_of_route_list node =
-  let a = Array.make (2 * (List.length node)) 0 in
-  let rec fill i = function
-    | [] -> a
-    | hd::tl ->
-        Array.set a i hd.dest;
-        Array.set a (i+1) hd.cost;
-        fill (i+2) tl
-  in
-    fill 0 node
+type route = {
+  dest: int;
+  cost: int;
+}
 
 let readPlaces () =
   let f = open_in "agraph" in
-  let n = int_of_string (input_line f) in
+  let next_int () = Scanf.fscanf f " %d" (fun n -> n) in
+  let n = next_int () in
   let nodes = Array.init n (fun a -> []) in
-  let rec loop () =
-    let nums = Str.split (Str.regexp "[ \t]+") @@ input_line f in
-    let len = length nums in
-    if len = 3 then 
-      let (node, neighbour, cost) = (int_of_string (nth nums 0), int_of_string (nth nums 1), int_of_string (nth nums 2)) in
-      nodes.(node) <- ({dest= neighbour; cost=cost} :: nodes.(node));
-      loop ()
-    else ();
-  in try
-    loop();
-    (nodes, n)
-  with e ->
-    (nodes, n)
-      
-let rec getLongestPath nodes nodeID visited =
-  visited.(nodeID) <- true;
-  let max = ref 0 in
-  iter (fun neighbour -> if (not (visited.(neighbour.dest)))
-			 then (
-			   let dist = neighbour.cost + getLongestPath nodes neighbour.dest visited in
-			   if dist > !max then max := dist;)
-			 else ();)
-       nodes.(nodeID);
-  visited.(nodeID) <- false;
-  !max
+  begin
+    try while true do
+      let node = next_int () in
+      let dest = next_int () in
+      let cost = next_int () in
+      nodes.(node) <- ({dest; cost} :: nodes.(node));
+    done with _ -> ()
+  end;
+  (Array.map Array.of_list nodes, n)
 
-let rec getLongestPath2 (nodes: node2 array) nodeID visited =
+let rec getLongestPath nodes nodeID visited =
   visited.(nodeID) <- true;
   let rec loop nodes nodeID visited i maxDist =
     if i < 0 then maxDist
     else
-      let neighbours = nodes.(nodeID) in
-      let dest = neighbours.(i) in
-      let cost = neighbours.(i+1) in
-      if (not visited.(dest))
-      then
-	let dist = cost + getLongestPath2 nodes dest visited in
-	let newMax = if dist > maxDist then dist else maxDist in
-        loop nodes nodeID visited (i-2) newMax
+      let {dest; cost} = nodes.(nodeID).(i) in
+      if visited.(dest)
+      then loop nodes nodeID visited (i-1) maxDist
       else
-	loop nodes nodeID visited  (i-2) maxDist in
+        let dist = cost + getLongestPath nodes dest visited in
+	let newMax = if dist > maxDist then dist else maxDist in
+        loop nodes nodeID visited (i-1) newMax
+  in
   let (max: int) =
-    loop nodes nodeID visited (Array.length nodes.(nodeID) - 2) 0
+    loop nodes nodeID visited (Array.length nodes.(nodeID) - 1) 0
   in
   visited.(nodeID) <- false;
   max;;
-   
 
 let () =
   let (nodes, numNodes) = readPlaces() in
   let visited = Array.init numNodes (fun x -> false) in
-  let fstNodes = Array.map node2_of_route_list nodes in
   let start = Unix.gettimeofday() in
-  let len = getLongestPath2 fstNodes 0 visited in
-  printf "%d LANGUAGE Ocaml %d\n" len (int_of_float @@ 1000. *. (Unix.gettimeofday() -. start))
-  (*  print_int @@ getLongestPath nodes 0 visited;*)
+  let len = getLongestPath nodes 0 visited in
+  Printf.printf "%d LANGUAGE Ocaml %d\n"
+    len (int_of_float @@ 1000. *. (Unix.gettimeofday() -. start))


### PR DESCRIPTION
This PR undoes the evil manual-unboxing performed by @lpw25 in #29 , but on my (admittedly x86-64) machine the performance gain was not worth the ugliness.

Ten runs before this PR:

```
8981 LANGUAGE Ocaml 1219
8981 LANGUAGE Ocaml 1232
8981 LANGUAGE Ocaml 1260
8981 LANGUAGE Ocaml 1244
8981 LANGUAGE Ocaml 1239
8981 LANGUAGE Ocaml 1330
8981 LANGUAGE Ocaml 1242
8981 LANGUAGE Ocaml 1249
8981 LANGUAGE Ocaml 1250
8981 LANGUAGE Ocaml 1254
```

Ten runs after this PR:

```
8981 LANGUAGE Ocaml 1275
8981 LANGUAGE Ocaml 1290
8981 LANGUAGE Ocaml 1279
8981 LANGUAGE Ocaml 1280
8981 LANGUAGE Ocaml 1280
8981 LANGUAGE Ocaml 1277
8981 LANGUAGE Ocaml 1275
8981 LANGUAGE Ocaml 1286
8981 LANGUAGE Ocaml 1277
8981 LANGUAGE Ocaml 1275
```
