### PR TITLE
Switch from per-node std::vector to one big memory block for neighbors in C++

### DIFF
--- a/cpp.cpp
+++ b/cpp.cpp
@@ -29,7 +29,7 @@ std::pair<vector<node>, vector<route>> readPlaces(){
     nodes[node].nCount += 1;
     totalNeighbours += 1;
   }
-  // second pass: compute each node's offset in allNeighbours
+  // compute each node's offset in allNeighbours
   std::vector<route> allNeighbours(totalNeighbours);
   int cumulative = 0;
   for (auto &node : nodes) {
@@ -37,7 +37,7 @@ std::pair<vector<node>, vector<route>> readPlaces(){
     cumulative += node.nCount;
     node.nCount = 0;
   }
-  // fill in neighbours arrays
+  // second pass: fill in neighbours arrays
   text = ifstream("agraph");
   text >> numNodes;
   while (text >> node >> neighbour >> cost){


### PR DESCRIPTION
This pull request changes the memory layout of the C++ implementation.  Instead of per-node `std::vector`s of neighbors, each node contains an index and count for retrieving its neighbors from one big array.  This improves cache behavior.  On my machine it resulted in 15-20% speedup.  It should be easy to apply this optimization to many of the other languages too.

We could simplify the file-reading code if we relied on the file containing edges sorted by source node, but the previous implementation did not rely on that property, so this one does not either.
