### PR TITLE
Speed up Go program just a tiny bit

### DIFF
--- a/go.go
+++ b/go.go
@@ -51,13 +51,13 @@ func getLongestPath(nodes []node, nodeID int32, visited []bool) int32 {
 	visited[nodeID] = true
 	var max int32
 	for _, neighbour := range nodes[nodeID].neighbours {
-		if !visited[neighbour.to] {
-			dist := neighbour.cost + getLongestPath(nodes, neighbour.to, visited)
-			if dist > max {
-				max = dist
-			}
+		if visited[neighbour.to] {
+			continue
 		}
-
+		dist := neighbour.cost + getLongestPath(nodes, neighbour.to, visited)
+		if dist > max {
+			max = dist
+		}
 	}
 	visited[nodeID] = false
 	return max


### PR DESCRIPTION
I wanted to refactor the file input process, but turns out someone had beaten me to it.

While doing that I noticed that removing the negation inside the `if` statement brought ~5% savings on my laptop.

Before the change:
    8981 LANGUAGE Go 1304
    8981 LANGUAGE Go 1332
    8981 LANGUAGE Go 1301
    8981 LANGUAGE Go 1314
    8981 LANGUAGE Go 1331
    8981 LANGUAGE Go 1347

After the change:

```
  8981 LANGUAGE Go 1266
  8981 LANGUAGE Go 1280
  8981 LANGUAGE Go 1267
  8981 LANGUAGE Go 1253
  8981 LANGUAGE Go 1290
  8981 LANGUAGE Go 1263
  8981 LANGUAGE Go 1288
  8981 LANGUAGE Go 1253
```
