### PR TITLE
Improve rust performance

### DIFF
--- a/rs.rs
+++ b/rs.rs
@@ -1,64 +1,93 @@
+#![feature(slicing_syntax)]
+#![allow(deprecated)]
+
 extern crate time;
+extern crate test;
 
-use std::io::{BufferedReader, File};
-use time::precise_time_ns;
+use time::{precise_time_ns};
+use std::{cmp};
 
-struct Route {
-    dest: i32,
-    cost: i32,
-}
+use tree::{Node};
 
-struct Node {
-    neighbours: Vec<Route>,
-}
+mod tree {
+    use std::io::{BufferedReader, File};
+    use std::{mem};
+    use std::cell::{Cell};
 
-fn read_places() -> Vec<Node> {
-    let path = Path::new("agraph");
-    let mut file = BufferedReader::new(File::open(&path));
-    let mut lines = file.lines().map(|x| x.unwrap());
-
-    let numnodes: uint = match lines.next() {
-        Some(num) => from_str(num.as_slice().trim()).unwrap(),
-        _         => panic!("Error, first line of file should describe the amount of nodes")
-    };
-
-    let mut nodes = Vec::from_fn(numnodes, |_| Node { neighbours: Vec::with_capacity(numnodes) });
-
-    for line in lines {
-        let nums: Vec<&str> = line.split(' ').collect();
-        let node     : uint = from_str(nums[0]       ).expect("Error: node id was not a uint");
-        let neighbour: i32  = from_str(nums[1]       ).expect("Error: neighbour id was not an int");
-        let cost     : i32  = from_str(nums[2].trim()).expect("Error: route cost was not an int");
-        nodes[node].neighbours.push(Route {dest: neighbour, cost: cost});
+    pub struct Node {
+        routes: Box<[(*const Node, i32)]>,
+        pub visited: Cell<bool>,
     }
 
-    return nodes;
-}
-
-fn get_longest_path(nodes: &Vec<Node>, node_id: i32, visited: &mut Vec<bool>) -> i32 {
-    visited[node_id as uint] = true;
-    let mut max = 0i32;
-
-    for neighbour in nodes[node_id as uint].neighbours.iter() {
-        if !visited[neighbour.dest as uint] {
-            let dist = neighbour.cost + get_longest_path(nodes, neighbour.dest, visited);
-
-            if dist > max {
-                max = dist;
-            }
+    impl Node {
+        pub fn routes(&self) -> &[(&Node, i32)] {
+            unsafe { mem::transmute(self.routes[]) }
         }
     }
 
-    visited[node_id as uint] = false;
-    return max;
+    pub struct Tree {
+        nodes: Box<[Node]>,
+    }
+
+    impl Tree {
+        pub fn nodes(&self) -> &[Node] {
+            self.nodes[]
+        }
+    }
+
+    pub fn read_places() -> Tree {
+        let path = Path::new("agraph");
+        let mut file = BufferedReader::new(File::open(&path).unwrap());
+
+        let numnodes = match file.read_line() {
+            Ok(num) => num[].trim().parse().unwrap(),
+            _ => panic!("Error, first line of file should describe the amount of nodes")
+        };
+
+        let mut nodes = Vec::from_fn(numnodes, |_| Node {
+            routes: vec!().into_boxed_slice(),
+            visited: Cell::new(false),
+        }).into_boxed_slice();
+
+        let mut vec_nodes = Vec::from_fn(numnodes, |_| vec!());
+
+        while let Ok(line) = file.read_line() {
+            let nums: Vec<&str> = line.trim().split(' ').collect();
+            let src  = nums[0].parse().expect("Error: node id was not a uint");
+            let dest = nums[1].parse().expect("Error: neighbour id was not an int");
+            let cost = nums[2].parse().expect("Error: route cost was not an int");
+            vec_nodes[src].push((&nodes[dest] as *const Node, cost));
+        }
+
+        for (node, vec_node) in nodes.iter_mut().zip(vec_nodes.into_iter()) {
+            node.routes = vec_node.into_boxed_slice();
+        }
+
+        Tree { nodes: nodes }
+    }
+}
+
+fn get_longest_path(nodes: &[Node], cur: &Node) -> i32 {
+    let mut max = 0;
+
+    cur.visited.set(true);
+
+    for &(neighbor, cost) in cur.routes().iter() {
+        if !neighbor.visited.get() {
+            let dist = cost + get_longest_path(nodes, neighbor);
+            max = cmp::max(max, dist);
+        }
+    }
+
+    cur.visited.set(false);
+
+    max
 }
 
 fn main() {
-    let nodes = read_places();
-    let mut visited = Vec::from_elem(nodes.len(), false);
-    let startTime = precise_time_ns();
-    let path = get_longest_path(&nodes, 0, &mut visited);
-    let duration = (precise_time_ns() - startTime) / 1000000;
+    let tree = tree::read_places();
+    let start_time = precise_time_ns();
+    let path = get_longest_path(tree.nodes(), &tree.nodes()[0]);
+    let duration = (precise_time_ns() - start_time) / 1000000;
     println!("{} LANGUAGE Rust {}", path, duration);
 }
-


### PR DESCRIPTION
Instead of using vectors we build a real tree and thereby avoid all bounds checks.

When compiled with
```
rustc -C target-cpu=corei7 -C no-stack-check --opt-level 3 rs.rs
```
Old version: 8981 LANGUAGE Rust 1471
New version: 8981 LANGUAGE Rust 1249