### PR TITLE
Rename C-arm to C-fast and run it on X86

### DIFF
--- a/c_fast.c
+++ b/c_fast.c
@@ -174,6 +174,6 @@ int main() {
   
   timersub(&end, &start, &duration);
   ms = duration.tv_sec*1000 + duration.tv_usec/1000;
-  printf("%d LANGUAGE C-arm %llu\n", result, ms);
+  printf("%d LANGUAGE C-fast %llu\n", result, ms);
 }
 

--- a/makefile
+++ b/makefile
@@ -2,10 +2,13 @@ NUM_NODES = 10
 WORLD_SIZE = 1000
 
 
-buildall: c_arm f03 c fsharp cpp-gcc cpp-clang cpp_cached racket csharp java haskell ocaml lisp rust rust_unsafe go gccgo d nim oraclejava crystal
+buildall: c-fast c-fast-arm f03 c fsharp cpp-gcc cpp-clang cpp_cached racket csharp java haskell ocaml lisp rust rust_unsafe go gccgo d nim oraclejava crystal
 
-c_arm: c_arm.c
-	gcc -falign-functions=16 -marm -g -std=gnu99 -O2 -mcpu=native -fomit-frame-pointer c_arm.c -o ./c_arm
+c-fast-arm: c_fast.c
+	gcc -marm -falign-functions=32 -g -std=gnu99 -O2 -mcpu=native -fomit-frame-pointer c_fast.c -o ./c_fast_arm
+	
+c-fast: c_fast.c
+	gcc -falign-functions=32 -g -std=gnu99 -O2 -mcpu=native -fomit-frame-pointer c_fast.c -o ./c_fast
 
 f03:    f03.f03
 	gfortran -O2 -mcpu=native f03.f03 -o f03

--- a/runbench.sh
+++ b/runbench.sh
@@ -10,7 +10,8 @@ runners=( "mono fs.exe"\
 	"./cpp_gcc"\
 	"./cpp_clang"\
 	"./cpp_cached"\
-	"./c_arm"\
+	"./c_fast"\
+	"./c_fast_arm"\
 	"./rkt"\
 	"mono -O=all ./cs.exe"\
 	"java jv"\


### PR DESCRIPTION
It turns out that this implementation is also the fastest one on
x86 (on an i5-3210M).
Note that there are two makefile targets, c-fast and c-fast-arm.
c-fast will build on both X86 and ARM, but it is essential to
run c-fast-arm on ARM, which is compiled in ARM mode (as opposed
to Thumb) for best performance.